### PR TITLE
Replace AIC with lambda expression in code example

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,7 @@ public class Example {
     TreeTaggerWrapper tt = new TreeTaggerWrapper<String>();
     try {
       tt.setModel("/opt/treetagger/models/english.par:iso8859-1");
-      tt.setHandler(new TokenHandler<String>() {
-        public void token(String token, String pos, String lemma) {
-          System.out.println(token + "\t" + pos + "\t" + lemma);
-        }
-      });
+      tt.setHandler((token, pos, lemma) -> System.out.println(token + "\t" + pos + "\t" + lemma);
       tt.process(asList(new String[] { "This", "is", "a", "test", "." }));
     }
     finally {


### PR DESCRIPTION
The code example in the index page can be simplified by replacing the AIC-handler with an equivalent but less verbose Java 8 lambda expression.